### PR TITLE
Added acpi in dependencies list

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ The plugin is written in Lua and depends heavily on the Plenary library for its 
 
 - [nvim-lua/plenary.nvim](https://github.com/nvim-lua/plenary.nvim)
 - [nvim-tree/nvim-web-devicons](https://github.com/nvim-tree/nvim-web-devicons)
+- acpi installed on your system and in your PATH
 
 ## Installation
 Use your package manager to add the dependencies and the plugin. 


### PR DESCRIPTION
You forgot to add `acpi` to the list of dependencies, I was confused why it didn't work until I saw in your `acpi.lua` file that it is required for the plugin to get battery info (which makes sense)