### PR TITLE
Use power supply files

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This is a cross platform Neovim plugin to provide battery information including 
 The information is then provided as a programmatic API you can call from Lua and also suitable to add to your status line.
 
 ## Why?
-When I'm working on a small 12" laptop there's not a lot of screen real estate, so I tend to maximize my terminal window when editing code. Unfortunately, that means I can't see the battery status, and don't know how long I've got without switching windows. I decided to fix that by adding it to the the statusline.
+I was working on a small 12" laptop and there's not a lot of screen real estate, so I tended to maximize my terminal window when editing code. Unfortunately, that means I can't see the battery status, and don't know how long I've got without switching windows. I decided to fix that by adding it to the the statusline and this plugin was born.
 
 ## How?
 The plugin is written in Lua and depends heavily on the Plenary library for its excellent support for processes (Jobs). When you start the plugin (by calling `require"battery".setup({})`) it runs a job in the background every 5 minutes (or however often you want, see config) and updates the battery status. Then you can call `require"battery".get_status_line()` in your statusline plugin to show the battery percentage and an appropriate icon.
@@ -26,7 +26,7 @@ The plugin is written in Lua and depends heavily on the Plenary library for its 
 - [nvim-lua/plenary.nvim](https://github.com/nvim-lua/plenary.nvim)
 - [nvim-tree/nvim-web-devicons](https://github.com/nvim-tree/nvim-web-devicons)
 
-*NOTICE* Please check the nvim-web-devicons repo for information on breaking changes to Nerd Fonts. This dependency is used to show the icons in this plugin and requires a compatible font. Thank you to Github user @david-0609 for bringing this to my attention and updating the icons used in this application. Should you encounter missing icons please upgrade the font you are using so it is using 2.3 or 3.0.
+**NOTICE** Please check the nvim-web-devicons repo for information on breaking changes to Nerd Fonts. This dependency is used to show the icons in this plugin and requires a compatible font. Thank you to Github user @david-0609 for bringing this to my attention and updating the icons used in this application. Should you encounter missing icons please upgrade the font you are using so it is using 2.3 or 3.0.
 
 _If you do not wish to upgrade your font you can pin to a previous version of the plugin using tag v0.8.0 instead of the main branch._
 

--- a/lua/battery/battery.lua
+++ b/lua/battery/battery.lua
@@ -74,7 +74,10 @@ local function select_job()
   elseif vim.fn.executable("pmset") == 1 then
     log.debug("pmset battery job")
     return pmset.get_battery_info_job
-  elseif vim.fn.isdirectory("/sys/class/power_supply/") == 1 then
+  -- Ensure directory exists (isdirectory() == 1) and is readable ($(ls) doesn't contain "ls: cannot")
+  elseif vim.fn.isdirectory("/sys/class/power_supply/") == 1 and
+    -- TODO: Find better way to check for readability (exit code of `ls`?)
+    not vim.fn.system("ls /sys/class/power_supply/"):find("ls: cannot") then
     log.debug("/sys/class/power_supply/ battery job")
     return powersupply.get_battery_info_job
   elseif vim.fn.executable("acpi") == 1 then

--- a/lua/battery/battery.lua
+++ b/lua/battery/battery.lua
@@ -74,7 +74,7 @@ local function select_job()
   elseif vim.fn.executable("pmset") == 1 then
     log.debug("pmset battery job")
     return pmset.get_battery_info_job
-  elseif vim.fn.isdirectory("/sys/class/power_supply/") then
+  elseif vim.fn.isdirectory("/sys/class/power_supply/") == 1 then
     log.debug("/sys/class/power_supply/ battery job")
     return powersupply.get_battery_info_job
   elseif vim.fn.executable("acpi") == 1 then

--- a/lua/battery/battery.lua
+++ b/lua/battery/battery.lua
@@ -3,6 +3,7 @@ local M = {}
 local L = require("plenary.log")
 local powershell = require("battery.powershell")
 local pmset = require("battery.pmset")
+local powersupply = require("battery.powersupply")
 local acpi = require("battery.acpi")
 local config = require("battery.config")
 
@@ -73,6 +74,9 @@ local function select_job()
   elseif vim.fn.executable("pmset") == 1 then
     log.debug("pmset battery job")
     return pmset.get_battery_info_job
+  elseif vim.fn.isdirectory("/sys/class/power_supply/") then
+    log.debug("/sys/class/power_supply/ battery job")
+    return powersupply.get_battery_info_job
   elseif vim.fn.executable("acpi") == 1 then
     log.debug("acpi battery job")
     return acpi.get_battery_info_job

--- a/lua/battery/powershell.lua
+++ b/lua/battery/powershell.lua
@@ -4,63 +4,56 @@ local L = require("plenary.log")
 
 local log = L.new({ plugin = "battery" })
 
--- Info about battery based on Status field of win32 Battery
+-- Whether the AC power is connected based on Status field of win32 Battery
 -- see https://powershell.one/wmi/root/cimv2/win32_battery#battery-status
--- 3rd field is whether AC is attached or not. nil for "who knows?"
 -- Note that I'm guessing here.
-local win32_battery_status_info = {
-  { "Battery Power", false },
-  { "AC Power", true },
-  { "Fully Charged", true },
-  { "Low", true },
-  { "Critical", false },
-  { "Charging", true },
-  { "Charging and High", true },
-  { "Charging and Low", true },
-  { "Charging and Critical", true },
-  { "Undefined", nil },
-  { "Partially Charged", true },
+local status_code_to_ac_power = {
+  [1] = false, -- Battery Power
+  [2] = true, -- AC Power
+  [3] = true, -- Fully Charged
+  [4] = false, -- Low
+  [5] = false, -- Critical
+  [6] = true, -- Charging
+  [7] = true, -- Charging and High
+  [8] = true, -- Charging and Low
+  [9] = true, -- Charging and Critical
+  [10] = false, -- Undefined, we don't know so let's assume false
+  [11] = true, -- Partially Charged
 }
 
+-- For a laptop with two batteries, the returned json would be in this format:
+-- [
+--   {
+--     "EstimatedChargeRemaining": 93,
+--     "BatteryStatus": 2
+--   },
+--   {
+--     "EstimatedChargeRemaining": 93,
+--     "BatteryStatus": 2
+--   }
+-- ]
 local get_battery_info_powershell_command = {
-  "Get-CimInstance -ClassName Win32_Battery | Select-Object -Property EstimatedChargeRemaining,BatteryStatus",
+  "ConvertTo-Json @(Get-CimInstance -ClassName Win32_Battery | Select-Object -Property EstimatedChargeRemaining,BatteryStatus)",
 }
 
--- TODO would be nice to unit test the parser
---[[ Sample output:
-{ "",
-  "EstimatedChargeRemaining BatteryStatus",
-  "------------------------ -------------",
-  "                      92             1",
-  "",
-  "" }
-]]
---
-
--- Parse the response from the batter info job and update
+-- Parse the response json from the battery info job and update
 -- the battery status
 local function parse_powershell_battery_info(result, battery_status)
-  local count = 0
+  -- Decode the json response into a list of batteries
+  local batteries = vim.json.decode(table.concat(result, ""))
+  local count = #batteries -- The count is just the length of batteries
   local charge_total = 0
   local ac_power = nil
 
-  for _, line in ipairs(result) do
-    local found, _, charge, status = line:find("(%d+)%s+(%d+)")
-    if found then
-      count = count + 1
-      charge_total = charge_total + tonumber(charge)
-      -- only the first battery is used to determine charging or not
-      -- since they should all be the same
-      if not ac_power then
-        local info = win32_battery_status_info[status]
-        if info ~= nil and info[2] ~= nil then
-          ac_power = info[2]
-        else
-          ac_power = false -- we don't know so let's guess no
-        end
-      end
-    end
+  -- Add up total charge
+  for _, b in ipairs(batteries) do
+    charge_total = charge_total + b["EstimatedChargeRemaining"]
   end
+
+  -- only the first battery is used to determine charging or not
+  -- since they should all be the same
+  local status = batteries[1]["BatteryStatus"]
+  ac_power = status_code_to_ac_power[status]
 
   if count > 0 then
     battery_status.percent_charge_remaining = math.floor(charge_total / count)

--- a/lua/battery/powersupply.lua
+++ b/lua/battery/powersupply.lua
@@ -1,0 +1,73 @@
+-- Get battery info using /sys/class/power_supply/* files. Requires Linux
+
+local J = require("plenary.job")
+local L = require("plenary.log")
+local BC = require("util.chooser")
+local config = require("battery.config")
+local log = L.new({ plugin = "battery" })
+
+-- Convert lowercase status from `/sys/class/power_supply/BAT?/status`
+-- to whether AC power is connected
+local status_to_ac_power = {
+    ["full"] = true,
+    ["charging"] = true,
+    ["discharging"] = false,
+    ["unknown"] = false,
+}
+
+-- Parse the response from the battery info job and update
+-- the battery status
+local function parse_powersupply_battery_info(battery_paths, battery_status)
+  local count = #battery_paths
+
+  if count > 0 then
+    -- Set battery count
+    battery_status.battery_count = count
+
+    -- Read capacity file of first battery
+    local f = io.open(battery_paths[1] .. "/capacity", "r")
+    if not f then
+      return -- File doesn't exist
+    end
+    battery_status.percent_charge_remaining = f:read("n")
+    f:close()
+
+    -- Read status file of first battery
+    f = io.open(battery_paths[1] .. "/status", "r")
+    if not f then
+      return -- File doesn't exist
+    end
+    local status = f:read("l"):lower() -- Read line (without newline character), to lowercase
+    battery_status.ac_power = status_to_ac_power[status]
+    f:close()
+  else
+    battery_status.percent_charge_remaining = 100
+    battery_status.battery_count = count
+    battery_status.ac_power = true
+  end
+end
+
+local function get_battery_info_job(battery_status)
+  return J:new({
+    -- Find symbolic links in /sys/class/power_supply that start with BAT
+    -- These are the directories containing information files for each battery
+    command = "find",
+    args = {
+      "/sys/class/power_supply/",
+      "-type", "l",
+      "-name", "BAT*",
+    },
+    on_exit = function (j, return_value)
+      if return_value == 0 then
+        parse_powersupply_battery_info(j:result(), battery_status)
+        log.debug(vim.inspect(battery_status))
+      else
+        log.error(vim.inspect(j:result()))
+      end
+    end
+  })
+end
+
+return {
+  get_battery_info_job = get_battery_info_job
+}

--- a/lua/battery/powersupply.lua
+++ b/lua/battery/powersupply.lua
@@ -2,8 +2,6 @@
 
 local J = require("plenary.job")
 local L = require("plenary.log")
-local BC = require("util.chooser")
-local config = require("battery.config")
 local log = L.new({ plugin = "battery" })
 
 -- Convert lowercase status from `/sys/class/power_supply/BAT?/status`


### PR DESCRIPTION
Close #22

If the `/sys/class/power_supply` directory is present and readable, use the `/sys/class/power_supply/BAT?/*` files for battery information.