### PR TITLE
Attempt to fix WSL Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 test/vendor/*/
 doc/tags
+.vs/

--- a/lua/battery/parsers/init.lua
+++ b/lua/battery/parsers/init.lua
@@ -13,6 +13,7 @@ M.parsers = {
   powersupply = require('battery.parsers.powersupply'),
   acpi = require('battery.parsers.acpi'),
   termux_api = require('battery.parsers.termux-api'),
+  wsl = require('battery.parsers.wsl')
 }
 
 return M

--- a/lua/battery/parsers/init.lua
+++ b/lua/battery/parsers/init.lua
@@ -13,7 +13,7 @@ M.parsers = {
   powersupply = require('battery.parsers.powersupply'),
   acpi = require('battery.parsers.acpi'),
   termux_api = require('battery.parsers.termux-api'),
-  wsl = require('battery.parsers.wsl')
+  wsl = require('battery.parsers.wsl'),
 }
 
 return M

--- a/lua/battery/parsers/powersupply.lua
+++ b/lua/battery/parsers/powersupply.lua
@@ -92,7 +92,7 @@ end
 ---Check if this parser would work in the current environment
 ---@return boolean
 function M.check()
-  return file.is_readable_directory('/sys/class/power_supply/')
+  return file.is_readable_directory('/sys/class/power_supply/') and vim.fn.has('wsl') == 0
 end
 
 return M

--- a/lua/battery/parsers/wsl.lua
+++ b/lua/battery/parsers/wsl.lua
@@ -6,23 +6,8 @@ local J = require('plenary.job')
 local L = require('plenary.log')
 local log = L.new({ plugin = 'battery' })
 
--- Convert status code from PowerShell to whether AC power is connected
-local status_code_to_ac_power = {
-  [1] = false, -- Battery Power
-  [2] = true, -- AC Power
-  [3] = true, -- Fully Charged
-  [4] = false, -- Low
-  [5] = false, -- Critical
-  [6] = true, -- Charging
-  [7] = true, -- Charging and High
-  [8] = true, -- Charging and Low
-  [9] = true, -- Charging and Critical
-  [10] = false, -- Undefined, we don't know so let's assume false
-  [11] = true, -- Partially Charged
-}
 local get_battery_info_powershell_command = {
-    'Get-CimInstance -ClassName Win32_Battery | \
- Select-Object -Property EstimatedChargeRemaining,BatteryStatus',
+  'Get-WmiObject -Class Win32_Battery | Select-Object -ExpandProperty EstimatedChargeRemaining',
 }
 
 ---Parse the response from the battery info job and update
@@ -33,7 +18,7 @@ local function parse_wsl_battery_info(result, battery_status)
   local battery_info = result[1]:match('%d+')
   if battery_info then
     battery_status.percent_charge_remaining = tonumber(battery_info)
-    battery_status.ac_power = status_code_to_ac_power[tonumber(battery_info)]
+    battery_status.ac_power = false
     battery_status.battery_count = 1
   else
     battery_status.percent_charge_remaining = 100
@@ -47,7 +32,8 @@ end
 function M.get_battery_info_job(battery_status)
   return J:new({
     command = '/mnt/c/Windows/System32/WindowsPowerShell/v1.0/powershell.exe',
-    args = { '-Command', table.concat(get_battery_info_powershell_command, ' ') },    on_exit = function(j, return_value)
+    args = { '-Command', table.concat(get_battery_info_powershell_command, ' ') },
+    on_exit = function(j, return_value)
       if return_value == 0 then
         parse_wsl_battery_info(j:result(), battery_status)
         log.debug(vim.inspect(battery_status))

--- a/lua/battery/parsers/wsl.lua
+++ b/lua/battery/parsers/wsl.lua
@@ -47,8 +47,7 @@ end
 function M.get_battery_info_job(battery_status)
   return J:new({
     command = '/mnt/c/Windows/System32/WindowsPowerShell/v1.0/powershell.exe',
-    args = get_battery_info_powershell_command,
-    on_exit = function(j, return_value)
+    args = { '-Command', table.concat(get_battery_info_powershell_command, ' ') },    on_exit = function(j, return_value)
       if return_value == 0 then
         parse_wsl_battery_info(j:result(), battery_status)
         log.debug(vim.inspect(battery_status))

--- a/lua/battery/parsers/wsl.lua
+++ b/lua/battery/parsers/wsl.lua
@@ -1,0 +1,68 @@
+-- Get battery info using PowerShell in WSL. Requires Windows Subsystem for Linux (WSL)
+
+local M = {}
+
+local J = require('plenary.job')
+local L = require('plenary.log')
+local log = L.new({ plugin = 'battery' })
+
+-- Convert status code from PowerShell to whether AC power is connected
+local status_code_to_ac_power = {
+  [1] = false, -- Battery Power
+  [2] = true, -- AC Power
+  [3] = true, -- Fully Charged
+  [4] = false, -- Low
+  [5] = false, -- Critical
+  [6] = true, -- Charging
+  [7] = true, -- Charging and High
+  [8] = true, -- Charging and Low
+  [9] = true, -- Charging and Critical
+  [10] = false, -- Undefined, we don't know so let's assume false
+  [11] = true, -- Partially Charged
+}
+local get_battery_info_powershell_command = {
+    'Get-CimInstance -ClassName Win32_Battery | \
+ Select-Object -Property EstimatedChargeRemaining,BatteryStatus',
+}
+
+---Parse the response from the battery info job and update
+---the battery status
+---@param result string[]
+---@param battery_status BatteryStatus
+local function parse_wsl_battery_info(result, battery_status)
+  local battery_info = result[1]:match('%d+')
+  if battery_info then
+    battery_status.percent_charge_remaining = tonumber(battery_info)
+    battery_status.ac_power = status_code_to_ac_power[tonumber(battery_info)]
+    battery_status.battery_count = 1
+  else
+    battery_status.percent_charge_remaining = 100
+    battery_status.ac_power = true
+    battery_status.battery_count = 0
+  end
+end
+
+---@param battery_status BatteryStatus
+---@return unknown # Plenary job
+function M.get_battery_info_job(battery_status)
+  return J:new({
+    command = '/mnt/c/Windows/System32/WindowsPowerShell/v1.0/powershell.exe',
+    args = get_battery_info_powershell_command,
+    on_exit = function(j, return_value)
+      if return_value == 0 then
+        parse_wsl_battery_info(j:result(), battery_status)
+        log.debug(vim.inspect(battery_status))
+      else
+        log.error(vim.inspect(j:result()))
+      end
+    end,
+  })
+end
+
+---Check if this parser would work in the current environment
+---@return boolean
+function M.check()
+  return vim.fn.has 'wsl' == 1
+end
+
+return M

--- a/lua/battery/parsers/wsl.lua
+++ b/lua/battery/parsers/wsl.lua
@@ -15,16 +15,17 @@ local get_battery_info_powershell_command = {
 ---@param result string[]
 ---@param battery_status BatteryStatus
 local function parse_wsl_battery_info(result, battery_status)
-  local battery_info = result[1]:match('%d+')
-  if battery_info then
-    battery_status.percent_charge_remaining = tonumber(battery_info)
-    battery_status.ac_power = false
-    battery_status.battery_count = 1
-  else
-    battery_status.percent_charge_remaining = 100
-    battery_status.ac_power = true
-    battery_status.battery_count = 0
-  end
+    log.debug("WSL Battery Info Result: ", vim.inspect(result))
+    local battery_info = result[1] and result[1]:match('%d+')
+    if battery_info then
+      battery_status.percent_charge_remaining = tonumber(battery_info)
+      battery_status.ac_power = false
+      battery_status.battery_count = 1
+    else
+      battery_status.percent_charge_remaining = 100
+      battery_status.ac_power = true
+      battery_status.battery_count = 0
+    end
 end
 
 ---@param battery_status BatteryStatus


### PR DESCRIPTION
This pull request introduces a parser for retrieving battery information within the Windows Subsystem for Linux (WSL) environment. It leverages PowerShell commands to access battery data using the Win32_Battery WMI class, processes the results, and updates the battery status in a structured manner. Additionally, modifications were made to the existing powersupply.lua parser to improve compatibility checks.

Unfortunately, I had to utilize the command 
```powershell
'Get-WmiObject -Class Win32_Battery | Select-Object -ExpandProperty EstimatedChargeRemaining'
```
compared to your original command, which dropped support for rich status checking as done in powershell.lua . This could probably be fixed down the line.