### PR TITLE
Fixed: battery on horizontal mode overlaps plug icon

### DIFF
--- a/lua/battery/battery.lua
+++ b/lua/battery/battery.lua
@@ -153,6 +153,13 @@ parser implementation.'
         plug_icon = icons.specific.unplugged
       end
 
+			-- extra space to separate horizontal battery from plug symbol
+			if not config.vertical_icons then
+				if plug_icon ~= '' then
+					plug_icon = ' ' + plug_icon
+				end
+			end
+
       local percent = ''
       if config.current.show_percent == true then
         percent = ' ' .. battery_percent .. '%%'


### PR DESCRIPTION
Added a space between battery & plug when on horizontal icons mode.

Before:
<img width="47" alt="Screenshot 2025-03-17 at 3 32 18 PM" src="https://github.com/user-attachments/assets/59a9b334-16bd-4126-bac0-41fd1387554f" />
After:
<img width="55" alt="Screenshot 2025-03-17 at 3 32 42 PM" src="https://github.com/user-attachments/assets/6b6cf6be-c235-4a30-9d49-6ddf78a3315c" />
