### PR TITLE
docs: add syntax highlighting to README and `docs/battery.txt`

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Use your package manager to add the dependencies and the plugin.
 
 ### [Plug](https://github.com/junegunn/vim-plug)
 
-```
+```vim
 Plug 'nvim-lua/plenary.nvim'
 Plug 'nvim-tree/nvim-web-devicons'
 Plug 'justinhj/battery.nvim'
@@ -47,7 +47,7 @@ Plug 'justinhj/battery.nvim'
 
 ### [Packer](https://github.com/wbthomason/packer.nvim)
 
-```
+```lua
 use { 'justinhj/battery.nvim', requires = {{'nvim-tree/nvim-web-devicons'}, {'nvim-lua/plenary.nvim'}}}
 ```
 
@@ -56,15 +56,15 @@ Once installed you need to run the setup function and pass in an optional config
 
 There are some configuration options.
 
-```
+```vim
 lua << END
 local battery = require("battery")
 battery.setup({
-	update_rate_seconds = 30,           -- Number of seconds between checking battery status
-	show_status_when_no_battery = true, -- Don't show any icon or text when no battery found (desktop for example)
-	show_plugged_icon = true,           -- If true show a cable icon alongside the battery icon when plugged in
-	show_unplugged_icon = true,         -- When true show a diconnected cable icon when not plugged in
-	show_percent = true,                -- Whether or not to show the percent charge remaining in digits
+    update_rate_seconds = 30,           -- Number of seconds between checking battery status
+    show_status_when_no_battery = true, -- Don't show any icon or text when no battery found (desktop for example)
+    show_plugged_icon = true,           -- If true show a cable icon alongside the battery icon when plugged in
+    show_unplugged_icon = true,         -- When true show a diconnected cable icon when not plugged in
+    show_percent = true,                -- Whether or not to show the percent charge remaining in digits
     vertical_icons = true,              -- When true icons are vertical, otherwise shows horizontal battery icon
     multiple_battery_selection = 1,     -- Which battery to choose when multiple found. "max" or "maximum", "min" or "minimum" or a number to pick the nth battery found (currently linux acpi only)
 })
@@ -73,12 +73,12 @@ END
 
 ## Adding to [lualine](https://github.com/nvim-lualine/lualine.nvim)
 Ensure minimal setup in your config.
-```
+```vim
 lua require"battery".setup({})
 ```
 
 In your lualine config add the following.
-```
+```lua
 local nvimbattery = {
   function()
     return require("battery").get_status_line()
@@ -87,7 +87,7 @@ local nvimbattery = {
 }
 ```
 Add it where you want it, something like below.
-```
+```lua
 sections = { lualine_a = nvimbattery }
 ```
 
@@ -95,7 +95,7 @@ sections = { lualine_a = nvimbattery }
 
 Add this to your galaxy line config in the section you want:
 
-```
+```lua
 local gl = require 'galaxyline'
 local gls = gl.section
 

--- a/doc/battery.txt
+++ b/doc/battery.txt
@@ -1,5 +1,5 @@
-*battery.txt* Battery power indicator for your status line 
- ___       _   _                  _  ___   _____ __  __ 
+*battery.txt* Battery power indicator for your status line
+ ___       _   _                  _  ___   _____ __  __
 | _ ) __ _| |_| |_ ___ _ _ _  _  | \| \ \ / /_ _|  \/  |     ~
 | _ \/ _` |  _|  _/ -_) '_| || |_| .` |\ V / | || |\/| |     ~
 |___/\__,_|\__|\__\___|_|  \_, (_)_|\_| \_/ |___|_|  |_|     ~
@@ -28,21 +28,20 @@ Periodically, the plugin will poll for the battery power. How often that happens
 2. SETUP                                             *battery-setup*
 
 You must call setup to activate the plugin. For a simple configuration with
-all default options you can do the following: >
-
+all default options you can do the following:
+>lua
   local battery = require("battery")
   battery.setup({})
 <
-
 See |battery-configuration| for all the options. Once setup, you need to add
 it to your status line. Two configurations are presented here. Please open
 a PR if you would like to add a different status line plugin configuration.
 
-Galaxyline config: >
-
+Galaxyline config:
+>lua
   local gl = require 'galaxyline'
   local gls = gl.section
-  
+
   -- in this example 5th section on the right, change as needed!
   gls.right[5] = {
     BatteryNvim = {
@@ -60,9 +59,8 @@ Galaxyline config: >
     },
   }
 <
-
-Lualine config: >
-
+Lualine config:
+>lua
   local nvimbattery = {
     function()
       return require("battery").get_status_line()
@@ -78,20 +76,20 @@ Lualine config: >
 
 Once installed you need to run the setup function and pass in an optional config. This starts the internal timer so that the battery status is updated periodically. Since the process to get the battery can take a second or two, even though it happens in the background, I don't recommend setting it below about 10 seconds, and several minutes should be fine for most purposes. Running `setup` will always refresh the battery status.
 
-Options: >
-
+Options:
+>vim
   lua << END
   local battery = require("battery")
   battery.setup({
-  	update_rate_seconds = 30,           -- Number of seconds between checking battery status
-  	show_status_when_no_battery = true, -- Don't show any icon or text when no battery found (desktop for example)
-  	show_plugged_icon = true,           -- If true show a cable icon alongside the battery icon when plugged in
-  	show_unplugged_icon = true,         -- When true show a diconnected cable icon when not plugged in
-  	show_percent = true,                -- Whether or not to show the percent charge remaining in digits
+      update_rate_seconds = 30,           -- Number of seconds between checking battery status
+      show_status_when_no_battery = true, -- Don't show any icon or text when no battery found (desktop for example)
+      show_plugged_icon = true,           -- If true show a cable icon alongside the battery icon when plugged in
+      show_unplugged_icon = true,         -- When true show a diconnected cable icon when not plugged in
+      show_percent = true,                -- Whether or not to show the percent charge remaining in digits
       vertical_icons = true,              -- When true icons are vertical, otherwise shows horizontal battery icon
       multiple_battery_selection = 1,     -- Which battery to choose when multiple found. "max" or "maximum", "min" or "minimum" or a number to pick the nth battery found (currently linux acpi only)
   })
+  END
 <
 
-==============================================================================
 vim:tw=78:ts=8:ft=help:norl:noet:fen:noet:


### PR DESCRIPTION
Also place `>` on newlines (this seems to be the standard in the (Neo)Vim help files), and fix some instances of mixed tabs/spaces