### PR TITLE
feat(scripts): add dev-shell scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ test/vendor/*/
 doc/tags
 .vs/
 GEMINI.md
+
+.xdg/

--- a/README.md
+++ b/README.md
@@ -139,7 +139,6 @@ sections = { lualine_a = nvimbattery }
 ```
 
 ## Adding to [galaxyline](https://github.com/glepnir/galaxyline.nvim)
-
 Add this to your galaxy line config in the section you want:
 
 ```lua
@@ -167,9 +166,56 @@ gls.right[5] = {
 ## Diagnostics and debugging
 If something breaks you should see a standard Vim error telling you what the problem is. There is some info logging you will find wherever your Neovim cache is `:h stdpath`.
 
-For more than just info,warn and error logging you can enable debug logs which show a more verbose behaviour of the plugin using the following command to launch nvim.
+For more than just info, warn and error logging you can enable debug logs which show a more verbose behaviour of the plugin using the following command to launch nvim.
 
 `BATTERY_DEBUG=true nvim`
+
+## Development
+To develop the plugin, you may find it useful to use the dev-shell script to
+run in a consistent, minimal Neovim instance.
+
+For Linux/MacOS (bash):
+```sh
+. ./scripts/dev-shell.sh
+```
+
+For Windows (PowerShell):
+```ps1
+. ./scripts/DevShell.ps1
+```
+
+> [!NOTE]
+>
+> You may need to enable [Developer Mode](https://learn.microsoft.com/en-us/windows/advanced-settings/developer-mode)
+> if you are on Windows, since `DevShell.ps1` creates a symlink.
+
+Now, you can run Neovim using the `dev_init.lua` init script:
+```sh
+nvim -u ./scripts/dev_init.lua
+```
+
+This loads battery.nvim as a plugin, runs the `setup()` function and assigns
+some convenience functions for interactive testing.
+
+The following functions are available:
+```lua
+BatteryStatus = require('battery').get_battery_status
+BatteryStatusLine = require('battery').get_status_line
+```
+
+And they can be used like so:
+```vim
+" Get current battery status (table)
+= BatteryStatus()
+```
+```vim
+" Get formatted current battery status (string)
+= BatteryStatusLine()
+```
+
+> [!NOTE]
+>
+> Read through [CONTRIBUTING.md](./CONTRIBUTING.md) before creating a PR.
 
 ## Notes
 Inspired by [lambdalisue/battery.vim](https://github.com/lambdalisue/battery.vim), which in turn uses code from [b4b4r07/dotfiles](https://github.com/b4b4r07/dotfiles/blob/66dddda6803ada50a0ab879e5db784afea72b7be/.tmux/bin/battery#L10).

--- a/scripts/DevShell.ps1
+++ b/scripts/DevShell.ps1
@@ -1,0 +1,63 @@
+if ($env:DEV_SHELL) {
+    [Console]::Error.WriteLine("info: dev-shell already activated")
+    return
+}
+$env:DEV_SHELL = "battery.nvim"
+
+$repo = (Get-Location).Path
+$gitDir = Join-Path $repo ".git"
+if (-not (Test-Path -LiteralPath $gitDir -PathType Container)) {
+    [Console]::Error.WriteLine("error: `$PWD ($repo) is not a git repository")
+    return
+}
+
+$env:XDG_DATA_HOME = Join-Path $repo ".xdg/data"
+$env:XDG_CONFIG_HOME = Join-Path $repo ".xdg/config"
+$env:XDG_STATE_HOME = Join-Path $repo ".xdg/state"
+$env:XDG_CACHE_HOME = Join-Path $repo ".xdg/cache"
+
+foreach ($dir in @(
+        $env:XDG_DATA_HOME,
+        $env:XDG_CONFIG_HOME,
+        $env:XDG_STATE_HOME,
+        $env:XDG_CACHE_HOME
+    )) {
+    New-Item -ItemType Directory -Path $dir -Force | Out-Null
+}
+
+$packDir = Join-Path $env:XDG_CONFIG_HOME "nvim/pack/dev/opt"
+New-Item -ItemType Directory -Path $packDir -Force | Out-Null
+
+$linkPath = Join-Path $packDir "battery.nvim"
+if (Test-Path -LiteralPath $linkPath) {
+    $item = Get-Item -LiteralPath $linkPath -Force
+    $isReparsePoint = ($item.Attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0
+    if (-not $isReparsePoint) {
+        [Console]::Error.WriteLine("error: $linkPath already exists and is not a symlink or junction")
+        return
+    }
+} else {
+    try {
+        New-Item -ItemType SymbolicLink -Path $linkPath -Target $repo -ErrorAction Stop | Out-Null
+    } catch {
+        New-Item -ItemType Junction -Path $linkPath -Target $repo -ErrorAction Stop | Out-Null
+    }
+}
+
+if (-not $global:__BatteryDevShellPromptWrapped) {
+    $promptCommand = Get-Command prompt -CommandType Function -ErrorAction SilentlyContinue
+    if ($null -ne $promptCommand) {
+        $global:__BatteryDevShellOriginalPrompt = $promptCommand.ScriptBlock
+    }
+
+    function global:prompt {
+        $prefix = "(dev-shell) "
+        if ($global:__BatteryDevShellOriginalPrompt) {
+            return $prefix + (& $global:__BatteryDevShellOriginalPrompt)
+        }
+
+        return $prefix + "PS $((Get-Location).Path)> "
+    }
+
+    $global:__BatteryDevShellPromptWrapped = $true
+}

--- a/scripts/dev-shell.sh
+++ b/scripts/dev-shell.sh
@@ -1,0 +1,28 @@
+if [[ -n "$DEV_SHELL" ]]; then
+  echo "info: dev-shell already activated" >&2
+  return
+fi
+export DEV_SHELL=battery.nvim
+
+if ! [[ -d "$PWD/.git" ]]; then
+  echo "error: \$PWD ($PWD) is not a git repository" >&2
+  return
+fi
+
+REPO="$PWD"
+
+export XDG_DATA_HOME="$REPO/.xdg/data"
+export XDG_CONFIG_HOME="$REPO/.xdg/config"
+export XDG_STATE_HOME="$REPO/.xdg/state"
+export XDG_CACHE_HOME="$REPO/.xdg/cache"
+
+for dir in "$XDG_DATA_HOME" "$XDG_CONFIG_HOME" "$XDG_STATE_HOME" "$XDG_CACHE_HOME"; do
+  mkdir -p "$dir"
+done
+
+mkdir -p "$XDG_CONFIG_HOME/nvim/pack/dev/opt"
+if ! [[ -L "$XDG_CONFIG_HOME/nvim/pack/dev/opt/battery.nvim" ]]; then
+  ln -s "$REPO" "$XDG_CONFIG_HOME/nvim/pack/dev/opt/battery.nvim"
+fi
+
+PS1="(dev-shell) $PS1"

--- a/scripts/dev_init.lua
+++ b/scripts/dev_init.lua
@@ -9,9 +9,6 @@ if vim.env.DEV_SHELL ~= 'battery.nvim' then
   return
 end
 
-vim.pack.add({
-  'https://github.com/nvim-lua/plenary.nvim',
-})
 vim.cmd.packadd('battery.nvim')
 
 require('battery').setup({})

--- a/scripts/dev_init.lua
+++ b/scripts/dev_init.lua
@@ -1,9 +1,11 @@
 if vim.env.DEV_SHELL ~= 'battery.nvim' then
-  -- TODO: Calculate dev-shell script that should be run based
-  -- on platform (Linux/MacOS: dev-shell.sh, Windows: DevShell.ps1)
+  local script = 'dev-shell.sh'
+  if vim.fn.has('win32') == 1 then
+    script = 'DevShell.ps1'
+  end
   vim.notify(
     '  Not in battery.nvim dev-shell, exiting dev_init.lua early.\n'
-      .. '  Source scripts/dev-shell.sh to enter dev-shell.',
+      .. ('  Source scripts/%s to enter dev-shell.'):format(script),
     vim.log.levels.ERROR
   )
   return

--- a/scripts/dev_init.lua
+++ b/scripts/dev_init.lua
@@ -1,0 +1,20 @@
+if vim.env.DEV_SHELL ~= 'battery.nvim' then
+  -- TODO: Calculate dev-shell script that should be run based
+  -- on platform (Linux/MacOS: dev-shell.sh, Windows: DevShell.ps1)
+  vim.notify(
+    '  Not in battery.nvim dev-shell, exiting dev_init.lua early.\n'
+      .. '  Source scripts/dev-shell.sh to enter dev-shell.',
+    vim.log.levels.ERROR
+  )
+  return
+end
+
+vim.pack.add({
+  'https://github.com/nvim-lua/plenary.nvim',
+})
+vim.cmd.packadd('battery.nvim')
+
+require('battery').setup({})
+
+BatteryStatus = require('battery').get_battery_status
+BatteryStatusLine = require('battery').get_status_line


### PR DESCRIPTION
This PR creates two dev-shell scripts, which do the following:

- Set `$XDG_*` environment variables to be relative to the current repo (inside a `.xdg/` directory)
- Create the `$XDG_*` directories
- Symlink from `$XDG_CONFIG_HOME/nvim/pack/dev/opt/battery.nvim` to the repository
- Modify the shell prompt to have `(dev-shell)` prepended

This means that after sourcing the dev-shell script, you can open nvim, run `:packadd battery.nvim`, and then `require("battery").setup({})` to "install" the version of battery.nvim you have checked-out.

Running `nvim -u scripts/dev_init.lua` will do that for you.

**AI usage**
`scripts/dev-shell.sh` was _fully_ handwritten, but `scripts/DevShell.ps1` is a AI-generated port of `dev-shell.sh` into PowerShell.

I manually reviewed and tested `DevShell.ps1` on my own Windows computer.